### PR TITLE
add support for script and style block syntax highlighting

### DIFF
--- a/languages/pug/injections.scm
+++ b/languages/pug/injections.scm
@@ -1,1 +1,16 @@
-((javascript) @content (#set! "language" "javascript"))
+(tag
+  (tag_name) @_tag_name
+  (#eq? @_tag_name "script")
+  (children) @injection.content
+  (#set! injection.language "javascript")
+  (#set! injection.include-children))
+
+(tag
+  (tag_name) @_tag_name
+  (#eq? @_tag_name "style")
+  (children) @injection.content
+  (#set! injection.language "css")
+  (#set! injection.include-children))
+
+((javascript) @injection.content
+  (#set! injection.language "javascript"))


### PR DESCRIPTION
- Set the language for script blocks to JavaScript and style blocks to CSS so code blocks get syntax highlighting.

This does use the standard injection prefix for `injection.content`, `injection.language`, etc. but that is supported in zed as of January last year [zed#22268](https://github.com/zed-industries/zed/pull/22268).